### PR TITLE
Various bugfixes

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -248,25 +248,17 @@ impl App {
 
                 match input.state {
                     ElementState::Pressed => {
-                        // If the key is already pressed, then ignore this event.
+                        // Record the key as being pressed. If the key is
+                        // already pressed, then ignore this event.
                         if let Some(sc) = sc {
-                            if self.pressed_keys.contains(&Key::Sc(sc))
-                            {
+                            if !self.pressed_keys.insert(Key::Sc(sc)) {
                                 return;
                             }
                         }
                         if let Some(vk) = vk {
-                            if self.pressed_keys.contains(&Key::Vk(vk))
-                            {
+                            if !self.pressed_keys.insert(Key::Vk(vk)) {
                                 return;
                             }
-                        }
-
-                        if let Some(sc) = sc {
-                            self.pressed_keys.insert(Key::Sc(sc));
-                        }
-                        if let Some(vk) = vk {
-                            self.pressed_keys.insert(Key::Vk(vk));
                         }
 
                         self.handle_key_press(sc, vk);

--- a/src/app.rs
+++ b/src/app.rs
@@ -248,6 +248,20 @@ impl App {
 
                 match input.state {
                     ElementState::Pressed => {
+                        // If the key is already pressed, then ignore this event.
+                        if let Some(sc) = sc {
+                            if self.pressed_keys.contains(&Key::Sc(sc))
+                            {
+                                return;
+                            }
+                        }
+                        if let Some(vk) = vk {
+                            if self.pressed_keys.contains(&Key::Vk(vk))
+                            {
+                                return;
+                            }
+                        }
+
                         if let Some(sc) = sc {
                             self.pressed_keys.insert(Key::Sc(sc));
                         }

--- a/src/preferences/mod.rs
+++ b/src/preferences/mod.rs
@@ -58,7 +58,12 @@ lazy_static! {
     ))()
     .ok_or(PrefsError::NoExecutablePath);
     static ref NONPORTABLE: bool = {
-        if let Ok(mut p) = LOCAL_DIR.clone() {
+        // If we are on macOS, we are always nonportable (because macOS doesn't allow storing).
+        // files in the same directory as the executable.
+        if  cfg!(target_os = "macos") {
+            true
+        // If not, check if the `nonportable` file exists in the same directory as the executable.
+        } else if let Ok(mut p) = LOCAL_DIR.clone() {
             p.push("nonportable");
             p.exists()
         } else {

--- a/src/preferences/mod.rs
+++ b/src/preferences/mod.rs
@@ -58,12 +58,14 @@ lazy_static! {
     ))()
     .ok_or(PrefsError::NoExecutablePath);
     static ref NONPORTABLE: bool = {
-        // If we are on macOS, we are always nonportable (because macOS doesn't allow storing).
-        // files in the same directory as the executable.
-        if  cfg!(target_os = "macos") {
+        if cfg!(target_os = "macos") {
+            // If we are on macOS, we are always nonportable because macOS
+            // doesn't allow storing files in the same directory as the
+            // executable.
             true
-        // If not, check if the `nonportable` file exists in the same directory as the executable.
         } else if let Ok(mut p) = LOCAL_DIR.clone() {
+            // If not, check if the `nonportable` file exists in the same
+            // directory as the executable.
             p.push("nonportable");
             p.exists()
         } else {


### PR DESCRIPTION
This fixes two issues:

1. On MacOS, the new "portable" preferences file configuration wasn't working well, as the pref file couldn't be saved in the application folder. The change here makes it so MacOS automatically uses the "nonportable" file path (which is usually something like `~/Library/Application Support/Hyperspeedcube/`).

2. As per https://github.com/HactarCE/Hyperspeedcube/issues/21, added code to make it so key repeats are not processed, so holding down a key won't cause the motion to happen many times.