### PR TITLE
Changes to web URL resolution for better portability

### DIFF
--- a/Trunk.toml
+++ b/Trunk.toml
@@ -1,3 +1,3 @@
 [build]
-public_url = "https://hyperspeedcube.xyz/hyperspeedcube/"
+public_url = "/hyperspeedcube"
 filehash = false

--- a/index.html
+++ b/index.html
@@ -11,8 +11,6 @@
 
     <!-- config for our rust wasm binary. go to https://trunkrs.dev/assets/#rust for more customization -->
     <link data-trunk rel="rust" data-wasm-opt="2" />
-    <!-- this is the base url relative to which other urls will be constructed. trunk will insert this from the public-url option -->
-    <base data-trunk-public-url />
 
     <link data-trunk rel="icon" href="assets/favicon.ico">
 


### PR DESCRIPTION
Small tweaks to URL resolution. Removed base tag from HTML template, and made the URL in Trunk.toml relative to the hosting location. Should fix broken URL resolution on the web version.