### PR TITLE
Revert autogeneration, but keep absolute path in build script

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,7 +31,7 @@ jobs:
         # this is necessary for github pages where the site is deployed to username.github.io/repo_name and all files must be requested
         # relatively as eframe_template/favicon.ico. if we skip public-url option, the href paths will instead request username.github.io/favicon.ico which
         # will obviously return error 404 not found.
-        run: ./trunk build --release --public-url "/${GITHUB_REPOSITORY#*/}"
+        run: ./trunk build --release --public-url "/hyperspeedcube"
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@v4
         with:


### PR DESCRIPTION
Half reverting #47, but keeping the important part (the slash)