### PR TITLE
Disabled vendored dbus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1426,17 +1426,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dbus"
-version = "0.9.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bb21987b9fb1613058ba3843121dd18b163b254d8a6e797e144cbac14d96d1b"
-dependencies = [
- "libc",
- "libdbus-sys",
- "winapi",
-]
-
-[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3094,16 +3083,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
-name = "libdbus-sys"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06085512b750d640299b79be4bad3d2fa90a9c00b1fd9e1b46364f66f0485c72"
-dependencies = [
- "cc",
- "pkg-config",
-]
-
-[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3897,7 +3876,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9901cb49d7fc923b256db329ee26ffed69130bf05d74b9efdd1875c92d6af01"
 dependencies = [
  "bstr",
- "dbus",
  "normpath",
  "windows-sys 0.52.0",
 ]

--- a/hyperspeedcube/Cargo.toml
+++ b/hyperspeedcube/Cargo.toml
@@ -42,7 +42,7 @@ names = { version = "0.14.0", default-features = false }
 num_enum = "0.5.7"
 oklab = "1.0.1"
 once_cell = "1.9.0"
-opener = "0.7.0"
+opener = { version = "0.7.0", default-features = false }
 optick = { version = "1.3.4", optional = true }
 optick-attr = { version = "0.3.0", optional = true }
 parking_lot = "0.12.1"


### PR DESCRIPTION
This PR disables the `dbus-vendored` feature of the `opener` dependency.

On linux, `opener` depends on `dbus` which has a feature called `vendored` which causes a statically linked copy of libdbus to be included in the executable, as opposed to dynamically linking against a distro-provided `libdbus.so`. If another C library ends up depending on libdbus, it will link dynamically against `libdbus.so`, and the two copies of libdbus end up catastrophically interfering.

In practice this means HSC debug build always segfaults for me on startup.