### PR TITLE
Fallback to interaction position for cursor pos to support clicks on Safari

### DIFF
--- a/src/gui/puzzle_view.rs
+++ b/src/gui/puzzle_view.rs
@@ -33,7 +33,7 @@ pub fn build(ui: &mut egui::Ui, app: &mut App, puzzle_texture_id: egui::TextureI
     );
 
     // Update app cursor position.
-    app.cursor_pos = r.hover_pos().map(|pos| {
+    app.cursor_pos = r.hover_pos().or(r.interact_pointer_pos()).map(|pos| {
         let p = (pos - egui_rect.min) / egui_rect.size();
         // Transform from egui to wgpu coordinates.
         cgmath::point2(p.x * 2.0 - 1.0, 1.0 - p.y * 2.0)


### PR DESCRIPTION
This is a "dirty" fix to support clicks on Safari (desktop and mobile). For some reason, egui does not mark the puzzle image as hovered on or after a click event until the next mouse move1ment. This used to break all click inputs over the puzzle area since the position would be reported as `None` while handling the event. By falling back to `interact_pointer_pos` for the current position, click events are able to be correctly processed without affecting contexts where hover is correctly determined. The cursor position after a click before further cursor movement is still broken, but that is a relatively minor bug compared to the original. I have not determined the underlying issue as to why hover is broken on Safari after particular event types, and doing so is probably unnecessary as egui reworked the way hover is handled in later versions.