### PR TITLE
Fix shader values being overwritten

### DIFF
--- a/hyperdraw/src/gfx/shader.wgsl
+++ b/hyperdraw/src/gfx/shader.wgsl
@@ -195,11 +195,17 @@ fn transform_point_to_3d(vertex_index: i32, surface: i32, piece: i32) -> Transfo
         surface_idx++;
         piece_idx++;
     }
-    var old_pos = new_pos;
-    var old_normal = new_normal;
+    var old_pos = array<f32, NDIM>();
+    var old_normal = array<f32, NDIM>();
     var old_u: array<f32, NDIM>;
     var old_v: array<f32, NDIM>;
     var i: i32;
+
+    for (var j = 0; j < NDIM; j++) {
+        old_pos[j] = new_pos[j];
+        old_normal[j] = new_normal[j];
+    }
+
     if is_puzzle_vertex {
         // Apply piece transform.
         new_pos = array<f32, NDIM>();


### PR DESCRIPTION
The assignment `old_pos = new_pos` followed by the line `new_pos = array<f32, NDIM>();` seem to modify the values of `old_pos` to the point where 3D and 4D puzzles don't render when running HSC2 on my Linux machine.

By explicitly constructing a new array for `old_pos` ahead of time, the line `new_pos = array<f32, NDIM>();` does not seem to override the values of `old_pos` anymore.

This fix might be specific to my machine, though. Also let me know if there is a faster way to create deep copies of arrays in WGSL.

![Megaminx with three corners cycled being rendered in HSC2 on an old Linux machine](https://github.com/user-attachments/assets/3b4b0226-2325-4746-b070-3c0f82c729e3)
