### PR TITLE
Fix cargo build error when release flag specified

### DIFF
--- a/hyperspeedcube/src/main.rs
+++ b/hyperspeedcube/src/main.rs
@@ -17,6 +17,8 @@ mod gui;
 mod locales;
 mod util;
 
+use hyperpuzzle_core::Timestamp;
+
 /// Strings for the current locale.
 ///
 /// This can be made customizable in the future using the crate `atomic`.
@@ -58,7 +60,7 @@ fn main() -> eframe::Result<()> {
             let dir = hyperpaths::crash_report_dir()?;
             std::fs::create_dir_all(dir)?;
             let filename =
-                dir.join(format!("crash_{}.log", hyperpuzzle::Timestamp::now()).replace(':', '_'));
+                dir.join(format!("crash_{}.log", Timestamp::now()).replace(':', "_"));
             std::fs::write(&filename, &contents)?;
             eyre::Ok(filename)
         })();


### PR DESCRIPTION
With rustc 1.84.0, when I run `cargo build --release`, I get compile errors.
This small change seems to allow `cargo build --release`  to complete successfully.